### PR TITLE
feat(deepagent): integrate You.com Search API as a DeepAgent tool

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -17,3 +17,6 @@ LANGFUSE_BASE_URL = "http://localhost:3000"
 # 前端 PageAgent 开关（运行时注入）
 # 修改后要npm run build重新构建一下前端项目
 VITE_ENABLE_PAGE_AGENT="false"
+
+# You.com Search API（用于 DeepAgent 联网搜索）
+YOU_SEARCH_API_KEY=

--- a/agent/deepagent/deep_data_agent.py
+++ b/agent/deepagent/deep_data_agent.py
@@ -34,6 +34,7 @@ from agent.deepagent.tools.native_sql_tools import (
     sql_db_smart_search,
     sql_db_table_relationship,
 )
+from agent.deepagent.tools.youcom_search_tool import youcom_search
 from agent.deepagent.tools.tool_call_manager import get_tool_call_manager
 from services.skill_service import SkillService
 from common.datasource_util import (
@@ -367,7 +368,7 @@ class DeepAgent:
                 )
                 # 过滤掉 sql_db_list_tables，由 sql_db_smart_search 替代
                 toolkit_tools = [t for t in toolkit.get_tools() if t.name != "sql_db_list_tables"]
-                sql_tools = [sql_db_smart_search, sql_db_table_relationship] + toolkit_tools
+                sql_tools = [sql_db_smart_search, sql_db_table_relationship, youcom_search] + toolkit_tools
                 logger.info(f"SQLAlchemy 工具列表: {[t.name for t in sql_tools]}")
             else:
                 logger.info(f"数据源 {datasource_id} ({datasource.type}) 使用原生驱动连接")
@@ -383,6 +384,7 @@ class DeepAgent:
                     sql_db_query,
                     sql_db_query_checker,
                     sql_db_table_relationship,
+                    youcom_search,
                 ]
 
         # 获取启用的 deep skill 路径

--- a/agent/deepagent/tools/youcom_search_tool.py
+++ b/agent/deepagent/tools/youcom_search_tool.py
@@ -1,0 +1,120 @@
+"""
+You.com Search API tool for DeepAgent.
+
+API文档: https://you.com/specs/openapi_search_v1.yaml
+"""
+
+import json
+import logging
+import os
+from typing import Optional
+
+import requests
+from langchain_core.tools import tool
+
+from .tool_call_manager import get_tool_call_manager
+
+logger = logging.getLogger(__name__)
+
+YOU_SEARCH_API_URL = "https://ydc-index.io/v1/search"
+YOU_SEARCH_API_KEY = os.getenv("YOU_SEARCH_API_KEY", "").strip()
+
+
+def _get_session_id() -> str:
+    """获取当前会话ID，用于工具调用管理"""
+    from .native_sql_tools import _get_session_id as _get_ds_session
+    return _get_ds_session()
+
+
+def _check_tool_call(tool_name: str, query: Optional[str] = None) -> tuple[bool, str]:
+    """检查工具调用是否允许（研究工具也纳入会话管理）"""
+    session_id = _get_session_id()
+    manager = get_tool_call_manager()
+    return manager.check_before_call(session_id, tool_name, query)
+
+
+def _record_tool_call(tool_name: str, success: bool, query: Optional[str] = None) -> None:
+    """记录工具调用"""
+    session_id = _get_session_id()
+    manager = get_tool_call_manager()
+    manager.record_call(session_id, tool_name, success, query)
+    logger.debug(f"记录工具调用: tool={tool_name}, success={success}, session={session_id}")
+
+
+@tool
+def youcom_search(query: str) -> str:
+    """
+    通过 You.com Search API 搜索网络信息，返回带有标题、链接、内容摘要的搜索结果。
+    适用于需要实时网络信息的研究查询。
+
+    Args:
+        query: 搜索关键词或自然语言查询语句
+    """
+    # 检查是否允许调用
+    allowed, reason = _check_tool_call("youcom_search", query)
+    if not allowed:
+        return reason
+
+    api_key = os.getenv("YOU_SEARCH_API_KEY", "").strip()
+    if not api_key:
+        _record_tool_call("youcom_search", False, query)
+        return "错误: YOU_SEARCH_API_KEY 未设置。请在 .env.dev 中配置 You.com API 密钥。"
+
+    max_results = 10
+    url = YOU_SEARCH_API_URL
+    headers = {
+        "X-API-Key": api_key,
+        "Content-Type": "application/json",
+    }
+    payload = json.dumps({
+        "query": query,
+        "count": max_results,
+    })
+
+    try:
+        response = requests.post(url, headers=headers, data=payload, timeout=30)
+        if response.status_code == 200:
+            result_data = response.json()
+            web_results = result_data.get("results", {}).get("web", [])
+
+            if not web_results:
+                _record_tool_call("youcom_search", True, query)
+                return "未找到相关搜索结果。"
+
+            formatted = []
+            for item in web_results:
+                title = item.get("title", "无标题")
+                link = item.get("url", "")
+                description = item.get("description") or ""
+                snippets = item.get("snippets", [])
+                snippet = snippets[0] if snippets else description
+                page_age = item.get("page_age", "")
+
+                entry = f"标题: {title}\n链接: {link}\n摘要: {snippet}"
+                if page_age:
+                    entry += f"\n时间: {page_age}"
+                formatted.append(entry)
+
+            result_str = "\n---\n".join(formatted)
+            _record_tool_call("youcom_search", True, query)
+            return result_str
+
+        elif response.status_code == 401:
+            _record_tool_call("youcom_search", False, query)
+            return f"错误: You.com API 密钥无效或已过期 (HTTP {response.status_code})。"
+        elif response.status_code == 403:
+            _record_tool_call("youcom_search", False, query)
+            return f"错误: You.com API 密钥缺少所需权限 (HTTP {response.status_code})。"
+        else:
+            _record_tool_call("youcom_search", False, query)
+            return f"错误: You.com Search API 请求失败 (HTTP {response.status_code}): {response.text[:200]}"
+
+    except requests.exceptions.Timeout:
+        _record_tool_call("youcom_search", False, query)
+        return "错误: You.com Search API 请求超时（30秒）。"
+    except requests.exceptions.RequestException as e:
+        _record_tool_call("youcom_search", False, query)
+        return f"错误: You.com Search API 请求失败: {str(e)[:200]}"
+    except Exception as e:
+        _record_tool_call("youcom_search", False, query)
+        return f"错误: {str(e)[:200]}"


### PR DESCRIPTION
PR描述（中文）：

摘要

- 集成 You.com Search API 作为 DeepAgent 的可调用工具 (youcom_search)，在 REPORT_QA 流水线中启用实时网络搜索
- 工具同时注册到 SQLAlchemy 和原生驱动工具列表中，无论查询走哪条后端路径都可以使用
- 返回格式化的搜索结果，包含标题、链接、摘要和页面时间
                                                                                                                                                                     
改动

- agent/deepagent/tools/youcom_search_tool.py — 新工具实现
- agent/deepagent/deep_data_agent.py — 在 SQLAlchemy 和原生驱动工具列表中注册工具
- .env.dev — 添加 YOU_SEARCH_API_KEY= 占位符

测试计划

- 全部13个单元测试通过（独立运行，无外部依赖）：python tests/test_youcom_search_tool.py
- 使用有效 API key 验证 DeepAgent REPORT_QA 网络搜索端到端可用
- 确认搜索结果在 SSE 流式响应中正确渲染

备注                                                                                                                                                               

- 使用 X-API-Key 请求头（非 Authorization: Bearer）
- 端点：https://ydc-index.io/v1/search
- 需要在 .env.dev 中设置 YOU_SEARCH_API_KEY
- 本地测试文件因 .gitignore: tests/* 规则未提交

Summary

- Integrates You.com Search API into the DeepAgent system as a callable tool (youcom_search), enabling real-time web search within the REPORT_QA pipeline
- Tool is registered in both SQLAlchemy and native driver tool lists, so it's available regardless of which backend path handles the query
- Returns formatted results with title, link, snippet, and page age for each web result

Changes

- agent/deepagent/tools/youcom_search_tool.py — new tool implementation
- agent/deepagent/deep_data_agent.py — registered tool in SQLAlchemy and native driver tool lists
- .env.dev — added YOU_SEARCH_API_KEY= placeholder

Test plan

- All 13 unit tests pass (standalone, no external deps): python tests/test_youcom_search_tool.py
- Verify DeepAgent REPORT_QA query with web search works end-to-end with a valid API key
- Confirm search results render correctly in the SSE streaming response

Notes

- Uses X-API-Key header (not Authorization: Bearer)
- Endpoint: https://ydc-index.io/v1/search
- Requires YOU_SEARCH_API_KEY to be set in .env.dev
- Local tests are gitignored (tests/test_youcom_search_tool.py) — not committed due to .gitignore: tests/* rule in this repo