### PR TITLE
feat (sql-executor): 实现 SQL 自纠错循环，执行失败后自动重试生成

### DIFF
--- a/agent/text2sql/analysis/graph.py
+++ b/agent/text2sql/analysis/graph.py
@@ -16,6 +16,7 @@ from agent.text2sql.permission.filter_injector import permission_filter_injector
 from agent.text2sql.chart.generator import chart_generator
 from agent.text2sql.datasource.selector import datasource_selector
 from agent.text2sql.state.agent_state import AgentState
+from agent.text2sql.database.sql_error import MAX_SQL_ATTEMPTS, SqlErrorType
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +40,57 @@ def should_continue_after_datasource_selector(state: AgentState) -> str:
         logger.warning("数据源选择失败，进入异常处理节点")
         return "error_handler"
     return "schema_inspector"
+
+
+def should_retry_sql(state: AgentState) -> str:
+    """
+    sql_executor 之后的条件判断（SQL 自纠错循环）：
+    - 执行成功 → parallel_collector
+    - 执行失败+不可重试 → error_handler（快速失败）
+    - 执行失败+可重试+未达上限 → sql_generator（重试）
+    - 执行失败+可重试+已达上限 → error_handler（耗尽重试）
+    """
+    result = state.get("execution_result")
+    attempts = state.get("attempts", 0)
+
+    if result and result.success:
+        state["correct_attempts"] = state.get("correct_attempts", 0) + 1
+        logger.info(
+            "SQL 执行成功（ attempts=%s, correct_attempts=%s ）",
+            attempts,
+            state["correct_attempts"],
+        )
+        return "parallel_collector"
+
+    is_retryable = state.get("is_retryable_error", False)
+    last_error = state.get("last_error_type", "unknown")
+
+    if not is_retryable:
+        logger.warning(
+            "SQL 执行失败（错误类型: %s），不可重试，进入错误处理",
+            last_error,
+        )
+        return "error_handler"
+
+    if attempts >= MAX_SQL_ATTEMPTS:
+        state["error_message"] = (
+            f"SQL 执行失败，已尝试 {MAX_SQL_ATTEMPTS} 次仍未能成功生成可执行的 SQL，"
+            "请换个问题或联系管理员。"
+        )
+        logger.warning(
+            "SQL 执行失败，已达到最大尝试次数 %s，进入错误处理",
+            MAX_SQL_ATTEMPTS,
+        )
+        return "error_handler"
+
+    state["attempts"] = attempts + 1
+    logger.info(
+        "SQL 执行失败（错误类型: %s），正在重新生成（第 %s/%s 次尝试）",
+        last_error,
+        state["attempts"],
+        MAX_SQL_ATTEMPTS,
+    )
+    return "sql_generator"
 
 
 def handle_datasource_error(state: AgentState) -> AgentState:
@@ -100,8 +152,16 @@ def create_graph(datasource_id: int = None):
     graph.add_edge("early_recommender", "sql_generator")
     graph.add_edge("sql_generator", "permission_filter")
     graph.add_edge("permission_filter", "sql_executor")
-    # 优化：并行执行 chart_generator 和 summarize（推荐问题已在后台执行）
-    graph.add_edge("sql_executor", "parallel_collector")
+    # SQL 自纠错循环：sql_executor 之后根据执行结果路由
+    graph.add_conditional_edges(
+        "sql_executor",
+        should_retry_sql,
+        {
+            "parallel_collector": "parallel_collector",
+            "sql_generator": "sql_generator",  # 重试回到 SQL 生成
+            "error_handler": "error_handler",
+        },
+    )
     # 统一收集：按顺序收集 summarize → 图表数据 → 推荐问题
     graph.add_edge("parallel_collector", "unified_collector")
     graph.add_edge("unified_collector", END)

--- a/agent/text2sql/database/db_service.py
+++ b/agent/text2sql/database/db_service.py
@@ -4,6 +4,11 @@ from sqlalchemy import create_engine
 
 from common.datasource_util import DatasourceConfigUtil, DatasourceConnectionUtil, DB, ConnectType
 from model import Datasource
+from agent.text2sql.database.sql_error import (
+    classify_sql_error,
+    SqlErrorType,
+    is_retryable_error,
+)
 
 warnings.filterwarnings("ignore", message=".*pkg_resources.*deprecated.*")
 
@@ -1279,6 +1284,9 @@ class DatabaseService:
             error_msg = "SQL 为空，无法执行"
             logger.warning(error_msg)
             state["execution_result"] = ExecutionResult(success=False, error=error_msg)
+            state["error_msg"] = error_msg
+            state["is_retryable_error"] = False
+            state["last_error_type"] = SqlErrorType.EMPTY_SQL.value
             return state
 
         is_allowed, security_error = validate_read_only_sql(
@@ -1292,6 +1300,9 @@ class DatabaseService:
                 success=False,
                 error=security_error,
             )
+            state["error_msg"] = security_error
+            state["is_retryable_error"] = False
+            state["last_error_type"] = SqlErrorType.SECURITY_VIOLATION.value
             return state
 
         logger.info("▶️ 执行 SQL 语句")
@@ -1327,7 +1338,17 @@ class DatabaseService:
                     state["execution_result"] = ExecutionResult(success=True, data=frame.to_dict(orient="records"))
                     logger.info(f"✅ SQL 执行成功，返回 {len(result_data)} 条记录")
         except Exception as e:
-            error_msg = f"执行 SQL 失败: {e}"
-            logger.error(error_msg, exc_info=True)
-            state["execution_result"] = ExecutionResult(success=False, error=str(e))
+            error_type, detailed_error = classify_sql_error(e)
+            retryable = is_retryable_error(error_type)
+            logger.error(
+                "SQL 执行失败: type=%s, retryable=%s, error=%s",
+                error_type.value,
+                retryable,
+                detailed_error,
+                exc_info=True,
+            )
+            state["execution_result"] = ExecutionResult(success=False, error=detailed_error)
+            state["error_msg"] = detailed_error
+            state["is_retryable_error"] = retryable
+            state["last_error_type"] = error_type.value
         return state

--- a/agent/text2sql/database/sql_error.py
+++ b/agent/text2sql/database/sql_error.py
@@ -1,0 +1,208 @@
+"""
+SQL 错误分类模块。
+
+将 SQL 执行异常分类为 SqlErrorType 枚举，并为路由决策提供
+is_retryable_error() 判断。错误信息同时传回 LLM 用于自纠错。
+"""
+
+from enum import Enum
+from typing import Tuple
+
+from agent.text2sql.state.agent_state import AgentState
+
+
+class SqlErrorType(Enum):
+    """
+    SQL 错误分类，供 should_retry_sql 路由函数使用。
+
+    不可重试（快速失败）：
+      SECURITY_VIOLATION  — SQL 安检失败（INSERT/UPDATE/DELETE 等危险操作）
+      PERMISSION_DENIED   — 数据库权限不足
+      EMPTY_SQL           — SQL 为空（生成逻辑 bug）
+
+    可重试（自纠错核心场景）：
+      SQL_SYNTAX_ERROR    — 语法错误，错误信息直接指导 LLM 修正
+      CONNECTION_TIMEOUT  — 连接超时
+      CONNECTION_REFUSED  — 连接被拒绝
+      TEMPORARY_UNAVAILABLE — 数据库临时不可用
+      LOCK_WAIT_TIMEOUT   — 锁等待超时
+      DEADLOCK            — 死锁
+      TABLE_NOT_EXIST     — 表不存在（可能是 LLM 打错字）
+      COLUMN_NOT_EXIST    — 列不存在（可能是 LLM 打错字）
+      UNKNOWN_ERROR       — 其他未知错误（保守策略，给 LLM 机会尝试）
+    """
+
+    # 不可重试
+    SECURITY_VIOLATION = "security_violation"
+    PERMISSION_DENIED = "permission_denied"
+    EMPTY_SQL = "empty_sql"
+
+    # 可重试
+    SQL_SYNTAX_ERROR = "sql_syntax_error"
+    CONNECTION_TIMEOUT = "connection_timeout"
+    CONNECTION_REFUSED = "connection_refused"
+    TEMPORARY_UNAVAILABLE = "temporary_unavailable"
+    LOCK_WAIT_TIMEOUT = "lock_wait_timeout"
+    DEADLOCK = "deadlock"
+    TABLE_NOT_EXIST = "table_not_exist"
+    COLUMN_NOT_EXIST = "column_not_exist"
+    UNKNOWN_ERROR = "unknown_error"
+
+
+# 最大 SQL 生成 + 执行尝试次数（含首次）
+MAX_SQL_ATTEMPTS = 3
+
+
+# ---------------------------------------------------------------------------
+# 连接错误检测（复用 deepagent / enhanced_common_agent 的成熟模式）
+# ---------------------------------------------------------------------------
+_CONNECTION_ERROR_TYPES = frozenset({
+    "ConnectionClosed",
+    "ConnectionResetError",
+    "BrokenPipeError",
+    "ConnectionError",
+    "OSError",
+    "TimeoutError",
+    "ConnectTimeoutError",
+    "PoolTimeoutError",
+})
+
+_CONNECTION_ERROR_KEYWORDS = frozenset({
+    "connection closed",
+    "connection reset",
+    "broken pipe",
+    "client disconnected",
+    "connection aborted",
+    "transport closed",
+    "connection refused",
+})
+
+
+def _is_connection_error(exception: Exception) -> bool:
+    """判断是否为连接类错误（复用 deepagent 模式）"""
+    error_type = type(exception).__name__
+    error_msg = str(exception).lower()
+    return (
+        error_type in _CONNECTION_ERROR_TYPES
+        or any(kw in error_msg for kw in _CONNECTION_ERROR_KEYWORDS)
+    )
+
+
+# ---------------------------------------------------------------------------
+# 错误分类
+# ---------------------------------------------------------------------------
+
+def classify_sql_error(
+    exception: Exception, security_error: str = None
+) -> Tuple[SqlErrorType, str]:
+    """
+    将 SQL 执行异常分类为 (SqlErrorType, 详细消息)。
+
+    Args:
+        exception:  执行阶段捕获的原始异常
+        security_error: 如果安检在执行前已失败，传入安检错误消息
+
+    Returns:
+        (SqlErrorType, 人类可读的错误消息)
+    """
+    error_msg_lower = str(exception).lower()
+    error_type_name = type(exception).__name__
+
+    # ── 1. 安检失败（不可重试，安全策略）───────────────────────────────
+    if security_error:
+        return SqlErrorType.SECURITY_VIOLATION, security_error
+
+    # ── 2. 空 SQL（不可重试，生成逻辑 bug）─────────────────────────────
+    if "sql 为空" in error_msg_lower or "sql is empty" in error_msg_lower:
+        return SqlErrorType.EMPTY_SQL, "SQL 为空，无法执行"
+
+    # ── 3. 语法错误（可重试，这是自纠错的核心场景）────────────────────
+    # 覆盖主流数据库的语法错误关键词
+    _SYNTAX_KEYWORDS = (
+        "syntax error",
+        "syntax error at",
+        "you have an error in your sql syntax",
+        "parse error",
+        "near \"",
+        "unexpected",
+        "invalid syntax",
+    )
+    if any(kw in error_msg_lower for kw in _SYNTAX_KEYWORDS):
+        return SqlErrorType.SQL_SYNTAX_ERROR, str(exception)
+
+    # ── 4. 权限不足（不可重试）────────────────────────────────────────
+    _PERMISSION_KEYWORDS = (
+        "permission denied",
+        "access denied",
+        "denied to user",
+        "not allowed to access",
+        "insufficient privilege",
+    )
+    if any(kw in error_msg_lower for kw in _PERMISSION_KEYWORDS):
+        return SqlErrorType.PERMISSION_DENIED, str(exception)
+
+    # ── 5. 连接类错误（可重试）────────────────────────────────────────
+    if _is_connection_error(exception):
+        if "timeout" in error_msg_lower or error_type_name in (
+            "TimeoutError",
+            "ConnectTimeoutError",
+            "PoolTimeoutError",
+        ):
+            return SqlErrorType.CONNECTION_TIMEOUT, str(exception)
+        if "refused" in error_msg_lower:
+            return SqlErrorType.CONNECTION_REFUSED, str(exception)
+        return SqlErrorType.TEMPORARY_UNAVAILABLE, str(exception)
+
+    # ── 6. 锁 / 死锁（可重试）────────────────────────────────────────
+    # 必须在独立 timeout 检查之前，因为 "lock wait timeout" 同时包含 "lock" 和 "timeout"
+    if "deadlock" in error_msg_lower:
+        return SqlErrorType.DEADLOCK, str(exception)
+    if "lock" in error_msg_lower or "lock wait" in error_msg_lower:
+        return SqlErrorType.LOCK_WAIT_TIMEOUT, str(exception)
+
+    # ── 7. 独立超时检查（不受 _is_connection_error 限制）────────────
+    # 覆盖 "timeout connecting to database" 等消息（不在连接错误类型中的超时）
+    if "timeout" in error_msg_lower or error_type_name in (
+        "TimeoutError",
+        "ConnectTimeoutError",
+        "PoolTimeoutError",
+    ):
+        return SqlErrorType.CONNECTION_TIMEOUT, str(exception)
+
+    # ── 8. 表 / 列不存在（可重试，可能是 LLM 打错字）─────────────────
+    # "relation" 是 PostgreSQL 对表的术语（如 "relation 'xxx' does not exist"）
+    if ("table" in error_msg_lower or "relation" in error_msg_lower) and (
+        "not exist" in error_msg_lower
+        or "doesn't exist" in error_msg_lower
+        or "不存在" in error_msg_lower
+        or "not found" in error_msg_lower
+    ):
+        return SqlErrorType.TABLE_NOT_EXIST, str(exception)
+
+    if "column" in error_msg_lower and (
+        "not exist" in error_msg_lower
+        or "doesn't exist" in error_msg_lower
+        or "不存在" in error_msg_lower
+        or "not found" in error_msg_lower
+        or "unknown column" in error_msg_lower
+    ):
+        return SqlErrorType.COLUMN_NOT_EXIST, str(exception)
+
+    # ── 8. 默认：未知但可重试（保守策略）─────────────────────────────
+    return SqlErrorType.UNKNOWN_ERROR, str(exception)
+
+
+# ---------------------------------------------------------------------------
+# 可重试判断
+# ---------------------------------------------------------------------------
+
+_NON_RETRYABLE = frozenset({
+    SqlErrorType.SECURITY_VIOLATION,
+    SqlErrorType.PERMISSION_DENIED,
+    SqlErrorType.EMPTY_SQL,
+})
+
+
+def is_retryable_error(error_type: SqlErrorType) -> bool:
+    """判断某错误类型是否可重试。"""
+    return error_type not in _NON_RETRYABLE

--- a/agent/text2sql/sql/generator.py
+++ b/agent/text2sql/sql/generator.py
@@ -149,7 +149,7 @@ def sql_generate(state: AgentState) -> AgentState:
             data_training = ""
         
         custom_prompt = ""  # 自定义提示词（暂时为空）
-        error_msg = ""  # 错误消息（暂时为空）
+        error_msg = state.get("error_msg", "")  # 从上次执行失败中获取，供 LLM 自纠错
         
         # 获取系统提示词和用户提示词
         system_prompt, user_prompt = prompt_builder.build_sql_prompt(
@@ -267,6 +267,8 @@ def sql_generate(state: AgentState) -> AgentState:
             
             chart_type = result.get("chart-type", result.get("chart_type", "table"))
             state["chart_type"] = chart_type
+            # 成功后清除 error_msg，避免污染后续步骤
+            state["error_msg"] = ""
             
             # 保存使用的表名（如果模板返回了 tables 字段）
             if "tables" in result:

--- a/agent/text2sql/state/agent_state.py
+++ b/agent/text2sql/state/agent_state.py
@@ -36,3 +36,7 @@ class AgentState(TypedDict):
     used_tables: Optional[List[str]]  # SQL 使用的表名列表
     bm25_tokens: Optional[List[str]]  # BM25 对用户问题的分词结果
     error_message: Optional[str]  # 异常信息（如数据源选择失败时的提示）
+    # ── SQL 自纠错循环新增字段 ──────────────────────────────────────
+    error_msg: Optional[str] = ""  # 最近一次 SQL 执行错误（传给 LLM 用于自纠错）
+    is_retryable_error: bool = False  # 该错误是否可重试
+    last_error_type: Optional[str] = None  # SqlErrorType.value 字符串，供路由判断

--- a/agent/text2sql/text2_sql_agent.py
+++ b/agent/text2sql/text2_sql_agent.py
@@ -269,6 +269,18 @@ class Text2SqlAgent:
             response, current_step, langgraph_step, t02_answer_data
         )
 
+        # 检测 SQL 重试尝试，推送进度消息
+        if langgraph_step == "sql_generator" and step_value:
+            attempts = step_value.get("attempts", 0)
+            if attempts > 1:
+                retry_msg = f"正在重新生成 SQL（第 {attempts}/3 次尝试）..."
+                await self._send_response(
+                    response,
+                    retry_msg,
+                    message_type="continue",
+                    data_type=DataTypeEnum.ANSWER.value[0],
+                )
+
         # 处理具体步骤内容
         if step_value:
             await self._process_step_content(


### PR DESCRIPTION
### 概述
实现 SQL 执行失败后的自动恢复机制。当 sql_executor 执行失败时，将具体错误信息回填至生成提示词，驱动 sql_generator 重新生成 SQL，并支持最多 3 次重试。解决执行异常被静默吞掉、attempts / correct_attempts 字段闲置、{error_msg} 占位符从未填充以及无条件边导致的流程错误传播等问题。

**Related Issues
Closes #227**

### 具体改动

**1. 异常分类**
在 execute_sql 中细化异常捕获，区分 可重试错误（如语法错误、连接超时、表不存在）与 不可重试错误（如权限不足、资源不存在）。
只有可重试错误才触发重试逻辑，不可重试错误直接终止并返回明确错误信息。

**2. 激活 attempts 计数**
在流程状态中启用 attempts 字段，初始值 0，每次执行失败并决定重试前自增。
重试条件：attempts < 3 且错误类型为可重试。

**3. 失败时回填 error_msg**
在重试分支中，将捕获的异常对象转换为描述字符串，并填入 prompt 模板的 {error_msg} 占位符。

更新相关 prompt 模板，确保 {error_msg} 在重试时有效渲染，为模型提供具体失败上下文。

**4. 条件路由改造**
将 sql_executor 后的无条件边替换为条件路由，逻辑如下：
成功 → 输出结果节点。
失败 & attempts < 3 → 回填 error_msg，返回 sql_generator 节点重新生成 SQL。
失败 & attempts ≥ 3（或不可重试） → 终止流程，返回最终错误信息。

### 关于测试
自动化测试，新增测试文件 tests/test_aimodel_service.py（随附件），覆盖核心场景，所有测试均已通过。
<img width="1235" height="709" alt="image" src="https://github.com/user-attachments/assets/cb7ab650-ae47-424c-b742-0bdacee7116e" />

☑ 所有单元测试均已通过
☑ 代码已通过 linter 检查
☑ 新增异常分支均有对应测试
### 附件清单：
pytest代码，测试截图与自动测试日志。
### [tests.zip](https://github.com/user-attachments/files/30488917/tests.zip)