### PR TITLE
fix: sanitize markdown HTML output with DOMPurify to prevent XSS

### DIFF
--- a/web/src/components/MarkdownPreview/plugins/markdown.ts
+++ b/web/src/components/MarkdownPreview/plugins/markdown.ts
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify'
 import MarkdownIt from 'markdown-it'
 import hljs from './highlight'
 import { preWrapperPlugin } from './preWrapper'
@@ -49,5 +50,10 @@ md.renderer.rules.image = function (tokens, idx, options, env, self) {
 md.use(preWrapperPlugin, {
   hasSingleTheme: true,
 })
+
+const originalRender = md.render.bind(md)
+md.render = (src: string, env?: any) => {
+  return DOMPurify.sanitize(originalRender(src, env))
+}
 
 export default md

--- a/web/src/views/knowledge/demand-manager.vue
+++ b/web/src/views/knowledge/demand-manager.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { marked } from 'marked' // 引入 marked 库
+import DOMPurify from 'dompurify'
+import { marked } from 'marked'
 import { NLayout, NLayoutContent, NLayoutHeader } from 'naive-ui'
 import * as GlobalAPI from '@/api'
 
@@ -271,7 +272,7 @@ function navigateToDetail(id) {
       <p
         v-for="(message, index) in messages"
         :key="index"
-        v-html="marked(message)"
+        v-html="DOMPurify.sanitize(marked(message))"
       ></p>
     </div>
     <div


### PR DESCRIPTION
markdown-it is configured with html:true, allowing raw HTML to pass through md.render() into v-html unsanitized. Wrap all render outputs with DOMPurify.sanitize() using the existing dompurify dependency.

Affected sinks:
- MarkdownPreview/index.vue v-html="renderedContent"
- skill-center.vue v-html="renderedDesc" / v-html="renderedSkillContent"
- demand-manager.vue v-html="marked(message)"

fix #230 